### PR TITLE
Add optional params to pass to Redis.new

### DIFF
--- a/lib/money/bank/historical.rb
+++ b/lib/money/bank/historical.rb
@@ -30,8 +30,9 @@ class Money
 
         # +Money::Currency+ relative to which all exchange rates will be cached
         attr_accessor :base_currency
-        # URL of the Redis server
+        # URL of the Redis server and other redis params
         attr_accessor :redis_url
+        attr_accessor :redis_params
         # Redis namespace in which the exchange rates will be cached
         attr_accessor :redis_namespace
         # OpenExchangeRates app ID
@@ -44,6 +45,7 @@ class Money
         def initialize
           @base_currency = Currency.new('EUR')
           @redis_url = 'redis://localhost:6379'
+          @redis_params = {}
           @redis_namespace = 'currency'
           @oer_app_id = nil
           @timeout = 15
@@ -61,6 +63,7 @@ class Money
       # - +oer_account_type+ - (optional) your OpenExchangeRates account type. Choose one of the values in the +Money::RatesProvider::OpenExchangeRates::AccountType+ module (default: +Money::RatesProvider::OpenExchangeRates::AccountType::ENTERPRISE+)
       # - +base_currency+ - (optional) +Money::Currency+ relative to which all the rates are stored (default: EUR)
       # - +redis_url+ - (optional) the URL of the Redis server (default: +redis://localhost:6379+)
+      # - +redis_params+ - (optional) parameters passed to Redis.new, for example to configure ssl behaviour
       # - +redis_namespace+ - (optional) Redis namespace to prefix all keys (default: +currency+)
       # - +timeout+ - (optional) set a timeout for the OER calls (default: 15 seconds)
       #
@@ -71,6 +74,7 @@ class Money
       #     config.oer_account_type = Money::RatesProvider::OpenExchangeRates::AccountType::FREE
       #     config.base_currency = Money::Currency.new('USD')
       #     config.redis_url = 'redis://localhost:6379'
+      #     config.redis_params = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
       #     config.redis_namespace = 'currency'
       #     config.timeout = 20
       #   end
@@ -87,6 +91,7 @@ class Money
         @rates = {}
         @store = RatesStore::HistoricalRedis.new(@base_currency,
                                                  Historical.configuration.redis_url,
+                                                 Historical.configuration.redis_params,
                                                  Historical.configuration.redis_namespace)
         @provider = RatesProvider::OpenExchangeRates.new(Historical.configuration.oer_app_id,
                                                          @base_currency,

--- a/lib/money/rates_store/historical_redis.rb
+++ b/lib/money/rates_store/historical_redis.rb
@@ -45,11 +45,12 @@ class Money
       #
       # - +base_currency+ - The base currency relative to which all rates are stored
       # - +redis_url+ - The URL of the Redis server
+      # - +redis_params+ - parameters passed to Redis.new
       # - +namespace+ - Namespace with which to prefix all Redis keys
 
-      def initialize(base_currency, redis_url, namespace)
+      def initialize(base_currency, redis_url, redis_params, namespace)
         @base_currency = base_currency
-        @redis = Redis.new(url: redis_url)
+        @redis = Redis.new({url: redis_url}.merge(redis_params))
         @namespace = namespace
       end
 

--- a/spec/bank/historical_spec.rb
+++ b/spec/bank/historical_spec.rb
@@ -67,7 +67,7 @@ class Money
         end
         # it's pointing to the same cache as the one in bank
         let(:new_store) do
-          RatesStore::HistoricalRedis.new(base_currency, redis_url, redis_namespace)
+          RatesStore::HistoricalRedis.new(base_currency, redis_url, {}, redis_namespace)
         end
 
         subject { bank.add_rates(currency_date_rate_hash) }
@@ -85,7 +85,7 @@ class Money
 
         # it's pointing to the same cache as the one in bank
         let(:new_store) do
-          RatesStore::HistoricalRedis.new(base_currency, redis_url, redis_namespace)
+          RatesStore::HistoricalRedis.new(base_currency, redis_url, {}, redis_namespace)
         end
         let(:datetime) { Time.utc(2017, 1, 4, 13, 0, 0) }
 

--- a/spec/rates_store/historical_redis_spec.rb
+++ b/spec/rates_store/historical_redis_spec.rb
@@ -26,7 +26,7 @@ class Money
 
       let(:base_currency) { Currency.new('EUR') }
       let(:namespace) { 'currency_test' }
-      let(:store) { HistoricalRedis.new(base_currency, redis_url, namespace) }
+      let(:store) { HistoricalRedis.new(base_currency, redis_url, {}, namespace) }
       let(:key_prefix) { 'currency_test:EUR' }
 
       let(:usd_date_rate_hash) do


### PR DESCRIPTION
When running on Heroku we have had to deal with errors from self signed certificates when using TLS connections to Redis.

The recommended work around is to set the `verify_mode` to `OpenSSL::SSL::VERIFY_NONE` in the Redis connection.

This PR allows passing a hash of options to the Redis connection, which will be passed to the `Redis.new` call.

```ruby
  # (optional) the URL of the Redis server (default: 'redis://localhost:6379')
  config.redis_url = Rails.configuration.redis_url
  config.redis_params = {ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}}
```

We've been using this patch on production without issue for multiple years.

Please let me know if you have any questions or change requests.
